### PR TITLE
fix: notify/handler  修正了支付回调通知

### DIFF
--- a/core/auth/validators/wechat_pay_notify_validator.go
+++ b/core/auth/validators/wechat_pay_notify_validator.go
@@ -2,8 +2,6 @@ package validators
 
 import (
 	"context"
-	"fmt"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/wechatpay-apiv3/wechatpay-go/core/auth"
@@ -15,18 +13,8 @@ type WechatPayNotifyValidator struct {
 }
 
 // Validate 对接收到的微信支付 API v3 通知请求报文进行验证
-func (v *WechatPayNotifyValidator) Validate(ctx context.Context, request *http.Request) error {
-	reqBody, err := request.GetBody()
-	if err != nil {
-		return fmt.Errorf("get request body err: %v", err)
-	}
-
-	body, err := ioutil.ReadAll(reqBody)
-	if err != nil {
-		return fmt.Errorf("read request body err: %v", err)
-	}
-
-	return v.validateHTTPMessage(ctx, request.Header, body)
+func (v *WechatPayNotifyValidator) Validate(ctx context.Context, headers http.Header, body []byte) error {
+	return v.validateHTTPMessage(ctx, headers, body)
 }
 
 // NewWechatPayNotifyValidator 使用 auth.Verifier 初始化一个 WechatPayNotifyValidator

--- a/core/auth/validators/wechat_pay_validator.go
+++ b/core/auth/validators/wechat_pay_validator.go
@@ -18,18 +18,19 @@ type wechatPayValidator struct {
 }
 
 func (v *wechatPayValidator) validateHTTPMessage(ctx context.Context, header http.Header, body []byte) error {
+	requestId := header.Get(consts.RequestID)
 	if v.verifier == nil {
-		return fmt.Errorf("you must init Validator with auth.Verifier")
+		return fmt.Errorf("you must init Validator with auth.Verifier. request-id=[%s]", requestId)
 	}
 
 	args, err := newWechatpayHeaders(header)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w request-id=[%s]", err, requestId)
 	}
 
 	message := args.buildMessage(ctx, header, body)
 	if err := v.verifier.Verify(ctx, args.SerialNo, message, args.Signature); err != nil {
-		return fmt.Errorf("validate verify fail serialNo=%s err=%v", args.SerialNo, err)
+		return fmt.Errorf("validate verify fail serialNo=%s request-id=[%s] err=%v", args.SerialNo, requestId, err)
 	}
 	return nil
 }

--- a/core/notify/notify.go
+++ b/core/notify/notify.go
@@ -23,13 +23,13 @@ type Handler struct {
 func (h *Handler) ParseNotifyRequest(ctx context.Context, request *http.Request, content interface{}) (
 	*Request, error,
 ) {
-	if err := h.validator.Validate(ctx, request); err != nil {
-		return nil, fmt.Errorf("not valid wechatpay notify request: %v", err)
-	}
-
 	body, err := getRequestBody(request)
 	if err != nil {
 		return nil, err
+	}
+
+	if err := h.validator.Validate(ctx, request.Header, body); err != nil {
+		return nil, fmt.Errorf("not valid wechatpay notify request: %v", err)
 	}
 
 	ret := new(Request)
@@ -54,16 +54,10 @@ func (h *Handler) ParseNotifyRequest(ctx context.Context, request *http.Request,
 }
 
 func getRequestBody(request *http.Request) ([]byte, error) {
-	reqBody, err := request.GetBody()
-	if err != nil {
-		return nil, fmt.Errorf("get request body err: %v", err)
-	}
-
-	body, err := ioutil.ReadAll(reqBody)
+	body, err := ioutil.ReadAll(request.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read request body err: %v", err)
 	}
-
 	return body, nil
 }
 

--- a/core/notify/notify.go
+++ b/core/notify/notify.go
@@ -58,6 +58,7 @@ func getRequestBody(request *http.Request) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read request body err: %v", err)
 	}
+	_ = request.Body.Close()
 	return body, nil
 }
 

--- a/core/notify/notify_test.go
+++ b/core/notify/notify_test.go
@@ -33,12 +33,12 @@ func Test_getRequestBody(t *testing.T) {
 	// Read Two times
 	bodyBytes, err = getRequestBody(req)
 	require.NoError(t, err)
-	assert.Equal(t, body, string(bodyBytes))
+	assert.Equalf(t, []byte{}, bodyBytes, "it can only read once")
 
 	// Read Three times
 	bodyBytes, err = getRequestBody(req)
 	require.NoError(t, err)
-	assert.Equal(t, body, string(bodyBytes))
+	assert.Equalf(t, []byte{}, bodyBytes, "it can only read once")
 }
 
 type contentType struct {


### PR DESCRIPTION
两个问题：
* 错误地使用了 request.GetBody 。 Body 和 GetBody 用哪个得看是 client 端还是 server 端。
  go 的这个实现比较坑，需要看注释才能明白。参考：  https://golang.org/pkg/net/http/#Request
  ```go
    // Body is the request's body.
    //
    // For client requests, a nil body means the request has no
    // body, such as a GET request. The HTTP Client's Transport
    // is responsible for calling the Close method.
    //
    // For server requests, the Request Body is always non-nil
    // but will return EOF immediately when no body is present.
    // The Server will close the request body. The ServeHTTP
    // Handler does not need to.
    //
    // Body must allow Read to be called concurrently with Close.
    // In particular, calling Close should unblock a Read waiting
    // for input.
    Body io.ReadCloser

    // GetBody defines an optional func to return a new copy of
    // Body. It is used for client requests when a redirect requires
    // reading the body more than once. Use of GetBody still
    // requires setting Body.
    //
    // For server requests, it is unused.
    GetBody func() (io.ReadCloser, error) // Go 1.8
  ```


* 实际支付后收到的回调通知里并未发现 RequestID 请求头，但是文档 [APIv3](https://pay.weixin.qq.com/wiki/doc/apiv3/wechatpay/wechatpay4_1.shtml) 说有。我之前在文档那反馈了，暂无答复。为了先跑通代码，我就先斩后奏去掉了对 RequestID 的引用。
