### PR TITLE
hotfix: 修复 notify.Handler 的Bug

### DIFF
--- a/core/auth/validators/wechat_pay_notify_validator.go
+++ b/core/auth/validators/wechat_pay_notify_validator.go
@@ -1,6 +1,7 @@
 package validators
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
@@ -16,15 +17,13 @@ type WechatPayNotifyValidator struct {
 
 // Validate 对接收到的微信支付 API v3 通知请求报文进行验证
 func (v *WechatPayNotifyValidator) Validate(ctx context.Context, request *http.Request) error {
-	reqBody, err := request.GetBody()
-	if err != nil {
-		return fmt.Errorf("get request body err: %v", err)
-	}
-
-	body, err := ioutil.ReadAll(reqBody)
+	body, err := ioutil.ReadAll(request.Body)
 	if err != nil {
 		return fmt.Errorf("read request body err: %v", err)
 	}
+
+	_ = request.Body.Close()
+	request.Body = ioutil.NopCloser(bytes.NewBuffer(body))
 
 	return v.validateHTTPMessage(ctx, request.Header, body)
 }

--- a/core/auth/validators/wechat_pay_validator.go
+++ b/core/auth/validators/wechat_pay_validator.go
@@ -45,9 +45,6 @@ func checkParameters(ctx context.Context, header http.Header, body []byte) error
 	_ = body
 
 	requestID := strings.TrimSpace(header.Get(consts.RequestID))
-	if requestID == "" {
-		return fmt.Errorf("empty %s", consts.RequestID)
-	}
 
 	if strings.TrimSpace(header.Get(consts.WechatPaySerial)) == "" {
 		return fmt.Errorf("empty %s, request-id=[%s]", consts.WechatPaySerial, requestID)

--- a/core/notify/notify.go
+++ b/core/notify/notify.go
@@ -2,6 +2,7 @@
 package notify
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -54,15 +55,13 @@ func (h *Handler) ParseNotifyRequest(ctx context.Context, request *http.Request,
 }
 
 func getRequestBody(request *http.Request) ([]byte, error) {
-	reqBody, err := request.GetBody()
-	if err != nil {
-		return nil, fmt.Errorf("get request body err: %v", err)
-	}
-
-	body, err := ioutil.ReadAll(reqBody)
+	body, err := ioutil.ReadAll(request.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read request body err: %v", err)
 	}
+
+	_ = request.Body.Close()
+	request.Body = ioutil.NopCloser(bytes.NewBuffer(body))
 
 	return body, nil
 }

--- a/core/notify/notify_test.go
+++ b/core/notify/notify_test.go
@@ -118,7 +118,6 @@ cTJOU9TxuGvNASMtjj7pYIerTx+xgZDXEVBWFW9PjJ0TV06tCRsgSHItgg==
 
 	headers := map[string]string{
 		"Content-Type":        "application/json",
-		"Request-Id":          "0885F2CF8606108F0518E29E944820F10B28E24A",
 		"Wechatpay-Nonce":     "EcZ9Cmy4Xyx1i6RlJQzLcCyEqDa26NBz",
 		"Wechatpay-Timestamp": "1624523846",
 		"Wechatpay-Serial":    "D7CE59D1F522D701",

--- a/core/notify/notify_test.go
+++ b/core/notify/notify_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -23,8 +24,7 @@ func Test_getRequestBody(t *testing.T) {
 	bodyBuf := &bytes.Buffer{}
 	bodyBuf.WriteString(body)
 
-	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1", bodyBuf)
-	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1", bodyBuf)
 
 	bodyBytes, err := getRequestBody(req)
 	require.NoError(t, err)
@@ -129,8 +129,7 @@ cTJOU9TxuGvNASMtjj7pYIerTx+xgZDXEVBWFW9PjJ0TV06tCRsgSHItgg==
 	bodyBuf := &bytes.Buffer{}
 	bodyBuf.WriteString(body)
 
-	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1", bodyBuf)
-	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1", bodyBuf)
 
 	for key, value := range headers {
 		req.Header.Set(key, value)


### PR DESCRIPTION
Fixed:
-  `notify.Handler` 与 `WechatPayNotifyValidator` 错误读取 Body 的方式
- 移除 `validator` 中对头部中的 `RequestID` 的必要性检查