### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,13 +293,11 @@ result, err := client.Request(
 
 ```go
 ctx := context.Background()
-// 使用商户私钥等初始化 client，并使它具有自动定时获取微信支付平台证书的能力
-opts := []core.ClientOption{
-	option.WithWechatPayAutoAuthCipher(mchID, mchCertificateSerialNumber, mchPrivateKey, mchAPIv3Key),
-}
-client, err := core.NewClient(ctx, opts...)
+// 1. 使用商户私钥等初始化 client，并使它具有自动定时获取微信支付平台证书的能力
+// 由于在回调通知的解密过程中无需使用client发送请求，所以这里不用获取client
+option.WithWechatPayAutoAuthCipher(mchID, mchCertificateSerialNumber, mchPrivateKey, mchAPIv3Key)
 	
-// 获取平台证书访问器
+// 2. 根据初始化的单例获取商户对应的平台证书访问器
 certVisitor := downloader.MgrInstance().GetCertificateVisitor(mchID)
 handler := notify.NewNotifyHandler(mchAPIv3Key, verifiers.NewSHA256WithRSAVerifier(certVisitor))
 ```


### PR DESCRIPTION
在我接入微信支付SDK的时候，发现回调通知解密推荐案例中，其中的client在后续的获取平台证书访问器中并没有用到。后面获取平台证书访问器只需要”证书相关功能“。所以为了更好的让新手接入微信SDK，这里只需要调用WithWechatPayAutoAuthCipher方法去初始化即可。在我实际的业务中也发现仅调用WithWechatPayAutoAuthCipher初始化方法是可行的