### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,44 +288,48 @@ result, err := client.Request(
 2. 调用 `handler.ParseNotifyRequest` 验签，并解密报文。
 
 ### 初始化
-+ 方法一（推荐）：先手动注册下载器，再获取微信平台证书访问器。
-适用场景：在仅需回调通知验签与解密的情景。如基础支付的回调通知。
++ 方法一（大多数场景）：先手动注册下载器，再获取微信平台证书访问器。
+适用场景： 仅需要对回调通知验证签名并解密的场景。例如，基础支付的回调通知。
 
 ```go
 ctx := context.Background()
-// 这是一个单纯的回调处理进程，没有使用 WithWechatPayAutoAuthCipher 创建商户的 client，则需要手动注册下载器
+// 1. 使用 `RegisterDownloaderWithPrivateKey` 注册下载器
 err := downloader.MgrInstance().RegisterDownloaderWithPrivateKey(ctx, mchPrivateKey, mchCertificateSerialNumber, mchID, mchAPIV3Key)
-
-// 注册完成，获取平台证书访问器
+// 2. 获取商户号对应的微信支付平台证书访问器
 certVisitor := downloader.MgrInstance().GetCertificateVisitor(mchID)
+// 3. 使用证书访问器初始化 `notify.Handler`
 handler := notify.NewNotifyHandler(mchAPIv3Key, verifiers.NewSHA256WithRSAVerifier(certVisitor))
-
 ```
 
-+ 方法二：如果你像 [发送请求](#发送请求) 那样使用 `WithWechatPayAutoAuthCipher` 初始化 `core.Client`，直接获取微信支付平台证书访问器初始化 `notify.Handler`。
-适用场景：验签与解密之后还会用到client进行api调用。如在开具电子发票前，获取用户填写抬头接口返回信息的验签与解密。
++ 方法二：像 [发送请求](#发送请求) 那样使用 `WithWechatPayAutoAuthCipher` 初始化 `core.Client`，然后再用client进行接口调用。
+适用场景：需要对回调通知验证签名并解密，并且后续需要使用 Client 的场景。例如，电子发票的回调通知，验签与解密后还需要通过 Client 调用用户填写抬头接口。
 
 ```go
 ctx := context.Background()
-// 使用商户私钥等初始化 client，并使它具有自动定时获取微信支付平台证书的能力
+// 1. 使用商户私钥等初始化 client，并使它具有自动定时获取微信支付平台证书的能力
 opts := []core.ClientOption{
 	option.WithWechatPayAutoAuthCipher(mchID, mchCertificateSerialNumber, mchPrivateKey, mchAPIv3Key),
 }
-client, err := core.NewClient(ctx, opts...)
-	
-// 获取平台证书访问器
+client, err := core.NewClient(ctx, opts...)	
+// 2. 获取商户号对应的微信支付平台证书访问器
 certVisitor := downloader.MgrInstance().GetCertificateVisitor(mchID)
+// 3. 使用证书访问器初始化 `notify.Handler`
 handler := notify.NewNotifyHandler(mchAPIv3Key, verifiers.NewSHA256WithRSAVerifier(certVisitor))
+// 4. 使用client进行接口调用
+// ...
 ```
 
 + 方法三：使用本地的微信支付平台证书和商户 APIv3 密钥初始化 `Handler`。
 适用场景：首次通过工具下载平台证书到本地，后续使用本地管理的平台证书进行验签与解密。
 
 ```go
+// 1. 初始化商户API v3 Key及微信支付平台证书
 mchAPIv3Key := "<your apiv3 key>"
-// 使用微信支付平台证书验证应答签名
-verifier := verifiers.NewSHA256WithRSAVerifier(core.NewCertificateMapWithList([]*x509.Certificate{wechatPayCert})) 
-handler := notify.NewNotifyHandler(mchAPIv3Key, verifier)
+wechatPayCert, err := utils.LoadCertificate("<your wechat pay certificate>")
+// 2. 使用本地管理的微信支付平台证书获取微信支付平台证书访问器
+certVisitor := core.NewCertificateMapWithList([]*x509.Certificate{wechatPayCert})
+// 3. 使用apiv3 key、证书访问器初始化 `notify.Handler`
+handler := notify.NewNotifyHandler(mchAPIv3Key, verifiers.NewSHA256WithRSAVerifier(certVisitor))
 ```
 
 建议：为了正确使用平台证书下载管理器，你应阅读并理解 [如何使用平台证书下载管理器](FAQ.md#如何使用平台证书下载管理器)。

--- a/README.md
+++ b/README.md
@@ -288,7 +288,8 @@ result, err := client.Request(
 2. 调用 `handler.ParseNotifyRequest` 验签，并解密报文。
 
 ### 初始化
-+ 方法一（推荐）：先手动注册下载器，再获取微信平台证书访问器。（在仅需回调通知验签与解密情景下使用）
++ 方法一（推荐）：先手动注册下载器，再获取微信平台证书访问器。
+适用场景：在仅需回调通知验签与解密的情景。如基础支付的回调通知。
 
 ```go
 ctx := context.Background()
@@ -301,7 +302,8 @@ handler := notify.NewNotifyHandler(mchAPIv3Key, verifiers.NewSHA256WithRSAVerifi
 
 ```
 
-+ 方法二：如果你像 [发送请求](#发送请求) 那样使用 `WithWechatPayAutoAuthCipher` 初始化 `core.Client`（验签与解密之后还会用到client），直接获取微信支付平台证书访问器初始化 `notify.Handler`。
++ 方法二：如果你像 [发送请求](#发送请求) 那样使用 `WithWechatPayAutoAuthCipher` 初始化 `core.Client`，直接获取微信支付平台证书访问器初始化 `notify.Handler`。
+适用场景：验签与解密之后还会用到client进行api调用。如在开具电子发票前，获取用户填写抬头接口返回信息的验签与解密。
 
 ```go
 ctx := context.Background()
@@ -317,6 +319,7 @@ handler := notify.NewNotifyHandler(mchAPIv3Key, verifiers.NewSHA256WithRSAVerifi
 ```
 
 + 方法三：使用本地的微信支付平台证书和商户 APIv3 密钥初始化 `Handler`。
+适用场景：首次通过工具下载平台证书到本地，后续使用本地管理的平台证书进行验签与解密。
 
 ```go
 mchAPIv3Key := "<your apiv3 key>"

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ result, err := client.Request(
 
 ### 初始化
 + 方法一（大多数场景）：先手动注册下载器，再获取微信平台证书访问器。
+
 适用场景： 仅需要对回调通知验证签名并解密的场景。例如，基础支付的回调通知。
 
 ```go
@@ -302,6 +303,7 @@ handler := notify.NewNotifyHandler(mchAPIv3Key, verifiers.NewSHA256WithRSAVerifi
 ```
 
 + 方法二：像 [发送请求](#发送请求) 那样使用 `WithWechatPayAutoAuthCipher` 初始化 `core.Client`，然后再用client进行接口调用。
+
 适用场景：需要对回调通知验证签名并解密，并且后续需要使用 Client 的场景。例如，电子发票的回调通知，验签与解密后还需要通过 Client 调用用户填写抬头接口。
 
 ```go
@@ -320,6 +322,7 @@ handler := notify.NewNotifyHandler(mchAPIv3Key, verifiers.NewSHA256WithRSAVerifi
 ```
 
 + 方法三：使用本地的微信支付平台证书和商户 APIv3 密钥初始化 `Handler`。
+
 适用场景：首次通过工具下载平台证书到本地，后续使用本地管理的平台证书进行验签与解密。
 
 ```go


### PR DESCRIPTION
根据：
1. 上一次commit
2. 微信支付开电子发票业务中回调通知接收之后还需要继续向微信支付发送服务请求
认为：
1. 先前的方法二更适合作为推荐方法（仅接收回调通知获取内容的情况-大多数场景）
2. 方法二更适合作为像开电子发票这种接收到回调后，解密内容后，拿到内容明文中的某些字段使用client继续发送服务请求的场景
进而对先前的commit进行了描述修改并将两个方法顺序按照使用场景的频次重新排序（因ZC说WithWechatPayAutoAuthCipher专门用来初始化Client的，所以就不考虑option.WithWechatPayAutoAuthCipher(mchID, mchCertificateSerialNumber, mchPrivateKey, mchAPIv3Key)作为不初始化client的推荐方法了）