### PR TITLE
单测: 使用兼容性更好的xgo替换gomonkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,16 +472,26 @@ func NewCustomClient(ctx context.Context, mchID string) (*core.Client, error) {
 
 开发者提交的代码，应能通过本 SDK 所有的测试用例。
 
-SDK 在单元测试中使用了 [agiledragon/gomonkey](https://github.com/agiledragon/gomonkey) 和 [stretchr/testify](https://github.com/stretchr/testify)，测试前请确认相关的依赖。使用以下命令获取所有的依赖。
+SDK 在单元测试中使用了 [xhd2015/xgo](https://github.com/xhd2015/xgo) 和 [stretchr/testify](https://github.com/stretchr/testify)，测试前请确认相关的依赖。
 
+运行`xgo`之前, 需要执行安装流程:
+```bash
+# macOS and Linux (and WSL)
+curl -fsSL https://github.com/xhd2015/xgo/raw/master/install.sh | bash
+
+# Windows
+powershell -c "irm github.com/xhd2015/xgo/raw/master/install.ps1|iex"
+```
+
+使用以下命令获取所有的依赖:
 ```bash
 go get -t -v
 ```
 
-由于 `gomonkey` 的原因，在执行测试用例时需要携带参数 `-gcflags=all=-l`。使用以下命令发起测试。
+然后使用`xgo`发起测试:
 
 ```bash
-go test -gcflags=all=-l ./...
+xgo test ./...
 ```
 
 ## 联系微信支付

--- a/core/auth/signers/sha256withrsa_signer_test.go
+++ b/core/auth/signers/sha256withrsa_signer_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/agiledragon/gomonkey"
+	"github.com/xhd2015/xgo/runtime/mock"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -138,10 +138,7 @@ func TestSha256WithRSASigner_Sign(t *testing.T) {
 }
 
 func TestSha256WithRSASigner_SignErrorSignSHA256WithRSA(t *testing.T) {
-	patches := gomonkey.NewPatches()
-	defer patches.Reset()
-
-	patches.ApplyFunc(
+	mock.Patch(
 		utils.SignSHA256WithRSA, func(source string, privateKey *rsa.PrivateKey) (signature string, err error) {
 			return "", fmt.Errorf("sign error")
 		},

--- a/core/auth/validators/validator_test.go
+++ b/core/auth/validators/validator_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agiledragon/gomonkey"
+	"github.com/xhd2015/xgo/runtime/mock"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wechatpay-apiv3/wechatpay-go/core/consts"
@@ -262,10 +262,7 @@ func TestWechatPayResponseValidator_WithoutVerifierShouldFail(t *testing.T) {
 }
 
 func TestWechatPayResponseValidator_ValidateReadBodyErrorShouldFail(t *testing.T) {
-	patches := gomonkey.NewPatches()
-	defer patches.Reset()
-
-	patches.ApplyFunc(ioutil.ReadAll, func(r io.Reader) ([]byte, error) {
+	mock.Patch(ioutil.ReadAll, func(r io.Reader) ([]byte, error) {
 		return nil, fmt.Errorf("read error")
 	})
 
@@ -320,10 +317,7 @@ func TestWechatPayNotifyValidator_Validate(t *testing.T) {
 }
 
 func TestWechatPayNotifyValidator_ValidateReadBodyError(t *testing.T) {
-	patches := gomonkey.NewPatches()
-	defer patches.Reset()
-
-	patches.ApplyFunc(ioutil.ReadAll, func(r io.Reader) ([]byte, error) {
+	mock.Patch(ioutil.ReadAll, func(r io.Reader) ([]byte, error) {
 		return nil, fmt.Errorf("read error")
 	})
 

--- a/core/cipher/ciphers/wechat_pay_cipher_test.go
+++ b/core/cipher/ciphers/wechat_pay_cipher_test.go
@@ -4,7 +4,6 @@ package ciphers
 
 import (
 	"context"
-	"github.com/agiledragon/gomonkey"
 	"reflect"
 	"testing"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/wechatpay-apiv3/wechatpay-go/core"
 	"github.com/wechatpay-apiv3/wechatpay-go/core/cipher/decryptors"
 	"github.com/wechatpay-apiv3/wechatpay-go/core/cipher/encryptors"
+	"github.com/xhd2015/xgo/runtime/mock"
 )
 
 type Student struct {
@@ -279,10 +279,9 @@ func TestWechatPayCipher_EncryptWithoutCertificate(t *testing.T) {
 }
 
 func TestWechatPayCipher_EncryptWithoutSerial(t *testing.T) {
-	patch := gomonkey.ApplyFunc(getEncryptSerial, func(ctx context.Context) (string, bool) {
+	mock.Patch(getEncryptSerial, func(ctx context.Context) (string, bool) {
 		return "", false
 	})
-	defer patch.Reset()
 	s := Student{
 		Name: "小可",
 		Age:  8,

--- a/core/downloader/downloader_mgr_test.go
+++ b/core/downloader/downloader_mgr_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestAutoCertificateDownloader(t *testing.T) {
-	patches := mockDownloadServer(t)
-	defer patches.Reset()
+	mockDownloadServer(t)
 
 	ctx := context.Background()
 

--- a/core/downloader/downloader_test.go
+++ b/core/downloader/downloader_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestNewCertificateDownloaderWithClient(t *testing.T) {
-	patches := mockDownloadServer(t)
-	defer patches.Reset()
+	mockDownloadServer(t)
 
 	ctx := context.Background()
 
@@ -48,8 +47,7 @@ func TestNewCertificateDownloaderWithClient(t *testing.T) {
 }
 
 func TestNewCertificateDownloader(t *testing.T) {
-	patches := mockDownloadServer(t)
-	defer patches.Reset()
+	mockDownloadServer(t)
 
 	privateKey, err := utils.LoadPrivateKey(testingKey(mockMchPrivateKey))
 	require.NoError(t, err)

--- a/core/downloader/mock_download_server_test.go
+++ b/core/downloader/mock_download_server_test.go
@@ -9,16 +9,15 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/agiledragon/gomonkey"
 	"github.com/stretchr/testify/require"
 	"github.com/wechatpay-apiv3/wechatpay-go/core/consts"
 	"github.com/wechatpay-apiv3/wechatpay-go/utils"
+	"github.com/xhd2015/xgo/runtime/mock"
 )
 
 const (
@@ -140,10 +139,9 @@ func init() {
 	}
 }
 
-func mockDownloadServer(t *testing.T) *gomonkey.Patches {
-	patches := gomonkey.NewPatches()
-	patches.ApplyMethod(
-		reflect.TypeOf(&http.Client{}), "Do", func(_ *http.Client, req *http.Request) (*http.Response, error) {
+func mockDownloadServer(t *testing.T) {
+	mock.Patch((*http.Client).Do,
+		func(_ *http.Client, req *http.Request) (*http.Response, error) {
 			resp := http.Response{
 				Status:        "200 OK",
 				StatusCode:    200,
@@ -176,7 +174,6 @@ func mockDownloadServer(t *testing.T) *gomonkey.Patches {
 			return &resp, nil
 		},
 	)
-	return patches
 }
 
 func testingKey(s string) string { return strings.ReplaceAll(s, "TESTING KEY", "PRIVATE KEY") }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/wechatpay-apiv3/wechatpay-go
 go 1.16
 
 require (
-	github.com/agiledragon/gomonkey v2.0.2+incompatible
 	github.com/stretchr/testify v1.8.1
+	github.com/xhd2015/xgo/runtime v1.0.17
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/agiledragon/gomonkey v2.0.2+incompatible h1:eXKi9/piiC3cjJD1658mEE2o3NjkJ5vDLgYjCQu0Xlw=
-github.com/agiledragon/gomonkey v2.0.2+incompatible/go.mod h1:2NGfXu1a80LLr2cmWXGBDaHEjb1idR6+FVlX5T3D9hw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -12,6 +10,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/xhd2015/xgo/runtime v1.0.17 h1:CsGcGnEcffjAaQvI4Z6KaG0IS3SrCvz+Diw7+WJzeLs=
+github.com/xhd2015/xgo/runtime v1.0.17/go.mod h1:9GBQ2SzJCzpD3T+HRN+2C0TUOGv7qIz4s0mad1xJ8Jo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
在这个PR中，我使用xgo替换了gomonkey。
xgo相对于gomonkey具有如下优点: 
- 不依赖asm, 纯go实现，兼容所有的OS和架构
- 并发安全，多组用例同时mock，不会相互影响
- API更加简单，不需要`defer patch.Reset()`等代码

xgo的项目地址: https://github.com/xhd2015/xgo

使用xgo进行单测的步骤:
1. 安装
```sh
# macOS and Linux (and WSL)
curl -fsSL https://github.com/xhd2015/xgo/raw/master/install.sh | bash

# windows
powershell -c "irm github.com/xhd2015/xgo/raw/master/install.ps1|iex"
```

2. 执行test
```sh
xgo test ./...
```

测试结果:
```sh
 xgo test ./...
xgo is taking a while to setup, please wait...
?       github.com/wechatpay-apiv3/wechatpay-go/cmd/wechatpay_download_certs    [no test files]
?       github.com/wechatpay-apiv3/wechatpay-go/core/auth       [no test files]
?       github.com/wechatpay-apiv3/wechatpay-go/core/cipher     [no test files]
ok      github.com/wechatpay-apiv3/wechatpay-go/core    0.928s
ok      github.com/wechatpay-apiv3/wechatpay-go/core/auth/credentials   1.249s
ok      github.com/wechatpay-apiv3/wechatpay-go/core/auth/signers       1.442s
?       github.com/wechatpay-apiv3/wechatpay-go/core/consts     [no test files]
ok      github.com/wechatpay-apiv3/wechatpay-go/core/auth/validators    1.692s
?       github.com/wechatpay-apiv3/wechatpay-go/core/option     [no test files]
?       github.com/wechatpay-apiv3/wechatpay-go/services        [no test files]
ok      github.com/wechatpay-apiv3/wechatpay-go/core/auth/verifiers     2.113s
ok      github.com/wechatpay-apiv3/wechatpay-go/core/cipher/ciphers     1.986s
ok      github.com/wechatpay-apiv3/wechatpay-go/core/cipher/decryptors  1.686s
ok      github.com/wechatpay-apiv3/wechatpay-go/core/cipher/encryptors  1.722s
?       github.com/wechatpay-apiv3/wechatpay-go/services/partnerpayments        [no test files]
?       github.com/wechatpay-apiv3/wechatpay-go/services/payments       [no test files]
ok      github.com/wechatpay-apiv3/wechatpay-go/core/downloader 12.718s
ok      github.com/wechatpay-apiv3/wechatpay-go/core/notify     1.926s
ok      github.com/wechatpay-apiv3/wechatpay-go/services/cashcoupons    2.426s [no tests to run]
ok      github.com/wechatpay-apiv3/wechatpay-go/services/certificates   3.012s
ok      github.com/wechatpay-apiv3/wechatpay-go/services/fileuploader   2.588s [no tests to run]
ok      github.com/wechatpay-apiv3/wechatpay-go/services/giftactivity   3.414s [no tests to run]
ok      github.com/wechatpay-apiv3/wechatpay-go/services/goldplan       3.594s [no tests to run]
ok      github.com/wechatpay-apiv3/wechatpay-go/services/lovefeast      3.796s [no tests to run]
ok      github.com/wechatpay-apiv3/wechatpay-go/services/merchantexclusivecoupon        3.298s [no tests to run]
ok      github.com/wechatpay-apiv3/wechatpay-go/services/partnerpayments/app    3.556s [no tests to run]
ok      github.com/wechatpay-apiv3/wechatpay-go/services/partnerpayments/h5     3.502s [no tests to run]
ok      github.com/wechatpay-apiv3/wechatpay-go/services/partnerpayments/jsapi  3.669s [no tests to run]
ok      github.com/wechatpay-apiv3/wechatpay-go/services/partnerpayments/native 3.704s [no tests to run]
ok      github.com/wechatpay-apiv3/wechatpay-go/services/partnertransferbatch   3.597s [no tests to run]
ok      github.com/wechatpay-apiv3/wechatpay-go/services/payments/app   3.425s [no tests to run]
ok      github.com/wechatpay-apiv3/wechatpay-go/services/payments/h5    3.589s [no tests to run]
ok      github.com/wechatpay-apiv3/wechatpay-go/services/payments/jsapi 3.499s [no tests to run]
ok      github.com/wechatpay-apiv3/wechatpay-go/services/payments/native        3.367s [no tests to run]
ok      github.com/wechatpay-apiv3/wechatpay-go/services/payrollcard    3.166s [no tests to run]
ok      github.com/wechatpay-apiv3/wechatpay-go/services/profitsharing  3.290s [no tests to run]
ok      github.com/wechatpay-apiv3/wechatpay-go/services/refunddomestic 3.332s [no tests to run]
ok      github.com/wechatpay-apiv3/wechatpay-go/services/retailstore    2.990s [no tests to run]
ok      github.com/wechatpay-apiv3/wechatpay-go/services/transferbatch  3.040s [no tests to run]
ok      github.com/wechatpay-apiv3/wechatpay-go/services/weixinpayscanandride   2.945s [no tests to run]
ok      github.com/wechatpay-apiv3/wechatpay-go/services/wexinpayscoreparking   2.921s [no tests to run]
ok      github.com/wechatpay-apiv3/wechatpay-go/utils   3.431s
ok      github.com/wechatpay-apiv3/wechatpay-go/utils/task      17.734s
```