### PR TITLE
支持微信支付公钥验签 （全新商户）

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,13 +13,13 @@ jobs:
     strategy:
       matrix:
         go:
+        - "1.22"
+        - "1.21"
+        - "1.20"
         - "1.19"
         - "1.18"
         - "1.17"
         - "1.16"
-        - "1.15"
-        - "1.14"
-        - "1.13"
     steps:
     - uses: actions/checkout@v2
 
@@ -39,10 +39,10 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: "1.16"
+        go-version: "1.19"
     - name: staticcheck
       run: |
-        go get -u honnef.co/go/tools/cmd/staticcheck@v0.2.2 &&
+        go install honnef.co/go/tools/cmd/staticcheck@latest &&
         $HOME/go/bin/staticcheck ./...
     - name: Revive Action
       uses: morphy2k/revive-action@v2.1.1

--- a/README.md
+++ b/README.md
@@ -488,6 +488,18 @@ handler := notify.NewNotifyHandler(
 	verifiers.NewSHA256WithRSAPubkeyVerifier(wechatpayPublicKeyID, *wechatPayPublicKey))
 ```
 
+如果你既有微信支付平台证书，又有公钥。那么，你可以在商户平台自助地从微信支付平台证书切换到公私钥，或者反过来。
+在切换期间，回调要同时支持使用平台证书和公钥的验签。 
+
+请参考下文，使用微信平台证书访问器和公钥一起初始化 `NotifyHandler`。
+
+```go
+// 初始化 notify.Handler
+handler := notify.NewNotifyHandler(
+	mchAPIv3Key,
+	verifiers.NewSHA256WithRSADuoVerifier(certificateVisitor, wechatpayPublicKeyID, *wechatPayPublicKey))
+```
+
 ## 常见问题
 
 常见问题请见 [FAQ.md](FAQ.md)。

--- a/core/auth/verifiers/sha256withrsa_duo_verifier.go
+++ b/core/auth/verifiers/sha256withrsa_duo_verifier.go
@@ -1,0 +1,28 @@
+package verifiers
+
+import (
+	"context"
+	"crypto/rsa"
+
+	"github.com/wechatpay-apiv3/wechatpay-go/core"
+)
+
+type SHA256WithRSADuoVerifier struct {
+	pubicKeyVerifier SHA256WithRSAPubkeyVerifier
+	certVerifier     SHA256WithRSAVerifier
+}
+
+func (v *SHA256WithRSADuoVerifier) Verify(ctx context.Context, serialNumber, message, signature string) error {
+	if serialNumber == v.pubicKeyVerifier.keyID {
+		return v.pubicKeyVerifier.Verify(ctx, serialNumber, message, signature)
+	} else {
+		return v.certVerifier.Verify(ctx, serialNumber, message, signature)
+	}
+}
+
+func NewSHA256WithRSADuoVerifier(getter core.CertificateGetter, keyID string, publicKey rsa.PublicKey) *SHA256WithRSADuoVerifier {
+	return &SHA256WithRSADuoVerifier{
+		*NewSHA256WithRSAPubkeyVerifier(keyID, publicKey),
+		*NewSHA256WithRSAVerifier(getter),
+	}
+}

--- a/core/auth/verifiers/sha256withrsa_pubkey_verifier.go
+++ b/core/auth/verifiers/sha256withrsa_pubkey_verifier.go
@@ -1,0 +1,45 @@
+// Copyright 2024 Tencent Inc. All rights reserved.
+
+// Package verifiers 微信支付 API v3 Go SDK 数字签名验证器
+package verifiers
+
+import (
+	"context"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+)
+
+// SHA256WithRSAPubkeyVerifier 数字签名验证器,使用微信支付提供的公钥验证签名
+type SHA256WithRSAPubkeyVerifier struct {
+	keyID     string
+	publicKey rsa.PublicKey
+}
+
+// Verify 使用微信支付提供的公钥验证签名
+func (v *SHA256WithRSAPubkeyVerifier) Verify(ctx context.Context, serialNumber, message, signature string) error {
+	if ctx == nil {
+		return fmt.Errorf("verify failed: context is nil")
+	}
+	if v.keyID != serialNumber {
+		return fmt.Errorf("verify failed: key-id[%s] does not match serial number[%s]", v.keyID, serialNumber)
+	}
+
+	sigBytes, err := base64.StdEncoding.DecodeString(signature)
+	if err != nil {
+		return fmt.Errorf("verify failed: signature is not base64 encoded")
+	}
+	hashed := sha256.Sum256([]byte(message))
+	err = rsa.VerifyPKCS1v15(&v.publicKey, crypto.SHA256, hashed[:], sigBytes)
+	if err != nil {
+		return fmt.Errorf("verify signature with public key error:%s", err.Error())
+	}
+	return nil
+}
+
+// NewSHA256WithRSAPubkeyVerifier 使用 rsa.PublicKey 初始化验签器
+func NewSHA256WithRSAPubkeyVerifier(keyID string, publicKey rsa.PublicKey) *SHA256WithRSAPubkeyVerifier {
+	return &SHA256WithRSAPubkeyVerifier{keyID: keyID, publicKey: publicKey}
+}

--- a/core/auth/verifiers/sha256withrsa_pubkey_verifier_test.go
+++ b/core/auth/verifiers/sha256withrsa_pubkey_verifier_test.go
@@ -1,0 +1,154 @@
+// Copyright 2021 Tencent Inc. All rights reserved.
+
+package verifiers
+
+import (
+	"context"
+	"crypto/rsa"
+	"testing"
+
+	"github.com/wechatpay-apiv3/wechatpay-go/utils"
+)
+
+const (
+	testPubKeyID = "F5765756002FDD77"
+	testPubKey   = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2VCTd91fnUn73Xy9DLvt
+/V62TVxRTEEstVdeRaZ3B3leO0pldE806mXO4RwdHXagHQ4vGeZN0yqm++rDsGK+
+U3AH7kejyD2pXshNP9Cq5YwbptiLGtjcquw4HNxJQUOmDeJf2vg6byms9RUipiq4
+SzbJKqJFlUpbuIPDpSpWz10PYmyCNeDGUUK65E5h2B834uxl1zNLYQCrkdBzb8oU
+xwYeP5a2DNxmjL5lsJML7DGr5znsevnoqGRwTm9fxCGfy8wus7hwKz6clt3Whmmd
+a7UAdb1c08hEQFVRbF14AR73xbnd8N0obCWJPCbzMCtkaSef4FdEEgEXJiw0VAJT
+8wIDAQAB
+-----END PUBLIC KEY-----`
+	// testExpectedSignature = "BKyAfU4iMCuvXMXS0Wzam3V/cnxZ+JaqigPM5OhljS2iOT95OO6Fsuml2JkFANJU9" +
+	// 	"K6q9bLlDhPXuoVz+pp4hAm6pHU4ld815U4jsKu1RkyaII+1CYBUYC8TK0XtJ8FwUXXz8vZHh58rrAVN1XwNyv" +
+	// 	"D1vfpxrMT4SL536GLwvpUHlCqIMzoZUguLli/K8V29QiOhuH6IEqLNJn8e9b3nwNcQ7be3CzYGpDAKBfDGPCq" +
+	// 	"Cv8Rw5zndhlffk2FEA70G4hvMwe51qMN/RAJbknXG23bSlObuTCN7Ndj1aJGH6/L+hdwfLpUtJm4QYVazzW7D" +
+	// 	"FD27EpSQEqA8bX9+8m1rLg=="
+)
+
+var (
+	pubKey *rsa.PublicKey
+)
+
+func init() {
+	var err error
+	pubKey, err = utils.LoadPublicKey(testPubKey)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestWechatPayPubKeyVerifier(t *testing.T) {
+	type args struct {
+		ctx          context.Context
+		serialNumber string
+		message      string
+		signature    string
+	}
+	tests := []struct {
+		name    string
+		fields  *rsa.PublicKey
+		args    args
+		wantErr bool
+	}{
+		{
+			name:   "verify success",
+			fields: pubKey,
+			args: args{
+				ctx:          context.Background(),
+				serialNumber: testPubKeyID,
+				signature:    testExpectedSignature,
+				message:      "source",
+			},
+			wantErr: false,
+		},
+		{
+			name:   "verify failed",
+			fields: pubKey,
+			args: args{
+				ctx:          context.Background(),
+				serialNumber: testPubKeyID,
+				signature:    testExpectedSignature,
+				message:      "wrong source",
+			},
+			wantErr: true,
+		},
+		{
+			name:   "verify failed with null context",
+			fields: pubKey,
+			args: args{
+				ctx:          nil,
+				serialNumber: testWechatPayVerifierPlatformSerialNumber,
+				signature:    testExpectedSignature,
+				message:      "source",
+			},
+			wantErr: true,
+		},
+		{
+			name:   "verify failed with empty keyId",
+			fields: pubKey,
+			args: args{
+				ctx:          context.Background(),
+				serialNumber: "",
+				signature:    testExpectedSignature,
+				message:      "source",
+			},
+			wantErr: true,
+		},
+		{
+			name:   "verify failed with empty message",
+			fields: pubKey,
+			args: args{
+				ctx:          context.Background(),
+				serialNumber: testPubKeyID,
+				signature:    testExpectedSignature,
+				message:      "",
+			},
+			wantErr: true,
+		},
+		{
+			name:   "verify failed with empty signature",
+			fields: pubKey,
+			args: args{
+				ctx:          context.Background(),
+				serialNumber: testPubKeyID,
+				signature:    "",
+				message:      "source",
+			},
+			wantErr: true,
+		},
+		{
+			name:   "verify failed with non-base64 signature",
+			fields: pubKey,
+			args: args{
+				ctx:          context.Background(),
+				serialNumber: testPubKeyID,
+				signature:    "invalid base64 signature",
+				message:      "source",
+			},
+			wantErr: true,
+		},
+		{
+			name:   "verify failed with no corresponding pubkey",
+			fields: pubKey,
+			args: args{
+				ctx:          context.Background(),
+				serialNumber: "invalid serial number",
+				signature:    testExpectedSignature,
+				message:      "source",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var verifier = NewSHA256WithRSAPubkeyVerifier(testPubKeyID, *tt.fields)
+			if err := verifier.Verify(tt.args.ctx, tt.args.serialNumber, tt.args.message,
+				tt.args.signature); (err != nil) != tt.wantErr {
+				t.Errorf("Verify() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/core/cipher/encryptors/wechat_pay_encryptor.go
+++ b/core/cipher/encryptors/wechat_pay_encryptor.go
@@ -10,7 +10,7 @@ import (
 	"github.com/wechatpay-apiv3/wechatpay-go/utils"
 )
 
-// WechatPayEncryptor 微信支付字符串加密器
+// WechatPayEncryptor 微信支付字符串加密器，使用微信支付平台证书
 type WechatPayEncryptor struct {
 	// 微信支付平台证书提供器
 	certGetter core.CertificateGetter
@@ -34,7 +34,8 @@ func (e *WechatPayEncryptor) SelectCertificate(ctx context.Context) (serial stri
 }
 
 // Encrypt 对字符串加密
-func (e *WechatPayEncryptor) Encrypt(ctx context.Context, serial, plaintext string) (ciphertext string, err error) {
+func (e *WechatPayEncryptor) Encrypt(
+	ctx context.Context, serial, plaintext string) (ciphertext string, err error) {
 	cert, ok := e.certGetter.Get(ctx, serial)
 
 	if !ok {

--- a/core/cipher/encryptors/wechat_pay_pubkey_encryptor.go
+++ b/core/cipher/encryptors/wechat_pay_pubkey_encryptor.go
@@ -1,0 +1,44 @@
+// Copyright 2024 Tencent Inc. All rights reserved.
+
+package encryptors
+
+import (
+	"context"
+	"crypto/rsa"
+	"fmt"
+
+	"github.com/wechatpay-apiv3/wechatpay-go/utils"
+)
+
+// WechatPayPubKeyEncryptor 微信支付字符串加密器，使用微信支付公钥
+type WechatPayPubKeyEncryptor struct {
+	// 微信支付公钥
+	publicKey rsa.PublicKey
+	// 公钥 ID
+	keyID string
+}
+
+// NewWechatPayPubKeyEncryptor 新建一个 WechatPayPubKeyEncryptor
+func NewWechatPayPubKeyEncryptor(keyID string, publicKey rsa.PublicKey) *WechatPayPubKeyEncryptor {
+	return &WechatPayPubKeyEncryptor{publicKey: publicKey, keyID: keyID}
+}
+
+// SelectCertificate 选择合适的微信支付平台证书用于加密
+// 返回公钥对应的 KeyId 作为证书序列号
+func (e *WechatPayPubKeyEncryptor) SelectCertificate(ctx context.Context) (serial string, err error) {
+	return e.keyID, nil
+}
+
+// Encrypt 对字符串加密
+func (e *WechatPayPubKeyEncryptor) Encrypt(ctx context.Context, serial, plaintext string) (ciphertext string, err error) {
+	if serial != e.keyID {
+		return "", fmt.Errorf("serial %v not match key-id %v", serial, e.keyID)
+	}
+
+	// 不需要对空串进行加密
+	if plaintext == "" {
+		return "", nil
+	}
+
+	return utils.EncryptOAEPWithPublicKey(plaintext, &e.publicKey)
+}


### PR DESCRIPTION
## 方案

1. 扩展了 `verifier` 和 `encryptors`，支持微信支付公钥
2. 将本地平台证书的方法标识为废弃

## 如何使用

```go
// 初始化 Client
opts := []core.ClientOption{
	option.WithWechatPayPublicKeyAuthCipher(
		mchID,
		mchCertificateSerialNumber, mchPrivateKey,
		wechatpayPublicKeyID, wechatpayPublicKey),
}
client, err := core.NewClient(ctx, opts...)

// 初始化 notify.Handler
handler := notify.NewNotifyHandler(
	mchAPIv3Key, 
	verifiers.NewSHA256WithRSAPubkeyVerifier(wechatpayPublicKeyID, *wechatPayPublicKey))

```