### PR TITLE
增加“商家转账到零钱” NotifyUrl 请求参数

### DIFF
--- a/services/transferbatch/api_transfer_batch_example_test.go
+++ b/services/transferbatch/api_transfer_batch_example_test.go
@@ -152,6 +152,7 @@ func ExampleTransferBatchApiService_InitiateBatchTransfer() {
 				UserName:       core.String("757b340b45ebef5467rter35gf464344v3542sdf4t6re4tb4f54ty45t4yyry45"),
 			}},
 			TransferSceneId: core.String("1000"),
+			NotifyUrl: core.String("https://www.weixin.qq.com/wxpay/pay.php"),
 		},
 	)
 

--- a/services/transferbatch/models.go
+++ b/services/transferbatch/models.go
@@ -410,6 +410,8 @@ type InitiateBatchTransferRequest struct {
 	TransferDetailList []TransferDetailInput `json:"transfer_detail_list"`
 	// 该批次转账使用的转账场景，如不填写则使用商家的默认场景，如无默认场景可为空，可前往“商家转账到零钱-前往功能”中申请。 如：1001-现金营销
 	TransferSceneId *string `json:"transfer_scene_id,omitempty"`
+	// 商户接收批次结果通知的URL，必须支持https，且只能是直接可访问的URL，不允许携带查询参数
+	NotifyUrl *string `json:"notify_url,omitempty"`
 }
 
 func (o InitiateBatchTransferRequest) MarshalJSON() ([]byte, error) {
@@ -452,6 +454,9 @@ func (o InitiateBatchTransferRequest) MarshalJSON() ([]byte, error) {
 
 	if o.TransferSceneId != nil {
 		toSerialize["transfer_scene_id"] = o.TransferSceneId
+	}
+	if o.NotifyUrl != nil {
+		toSerialize["notify_url"] = o.NotifyUrl
 	}
 	return json.Marshal(toSerialize)
 }
@@ -502,6 +507,12 @@ func (o InitiateBatchTransferRequest) String() string {
 		ret += fmt.Sprintf("TransferSceneId:%v", *o.TransferSceneId)
 	}
 
+	if o.NotifyUrl == nil {
+		ret += "NotifyUrl:<nil>"
+	} else {
+		ret += fmt.Sprintf("NotifyUrl:%v", *o.NotifyUrl)
+	}
+
 	return fmt.Sprintf("InitiateBatchTransferRequest{%s}", ret)
 }
 
@@ -550,6 +561,10 @@ func (o InitiateBatchTransferRequest) Clone() *InitiateBatchTransferRequest {
 		*ret.TransferSceneId = *o.TransferSceneId
 	}
 
+	if o.NotifyUrl != nil {
+		ret.NotifyUrl = new(string)
+		*ret.NotifyUrl = *o.NotifyUrl
+	}
 	return &ret
 }
 


### PR DESCRIPTION
发现请求参数最后有一个通知地址的可选项，但在 sdk 中没有发现这个字段
https://pay.weixin.qq.com/docs/merchant/apis/batch-transfer-to-balance/transfer-batch/initiate-batch-transfer.html#%E8%AF%B7%E6%B1%82%E5%8F%82%E6%95%B0 
https://github.com/wechatpay-apiv3/wechatpay-go/blob/main/services/transferbatch/models.go