### PR TITLE
Add RefundStatus field to models.go

### DIFF
--- a/services/refunddomestic/models.go
+++ b/services/refunddomestic/models.go
@@ -878,6 +878,9 @@ type Refund struct {
 	CreateTime *time.Time `json:"create_time"`
 	// 退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台（pay.weixin.qq.com）-交易中心，手动处理此笔退款。 枚举值： - SUCCESS—退款成功 - CLOSED—退款关闭 - PROCESSING—退款处理中 - ABNORMAL—退款异常 * `SUCCESS` - 退款成功 * `CLOSED` - 退款关闭 * `PROCESSING` - 退款处理中 * `ABNORMAL` - 退款异常
 	Status *Status `json:"status"`
+	// 退款到银行发现用户的卡作废或者冻结了，导致原路退款银行卡失败，可前往商户平台（pay.weixin.qq.com）-交易中心，手动处理此笔退款。 枚举值： - SUCCESS—退款成功 - CLOSED—退款关闭 - PROCESSING—退款处理中 - ABNORMAL—退款异常 * `SUCCESS` - 退款成功 * `CLOSED` - 退款关闭 * `PROCESSING` - 退款处理中 * `ABNORMAL` - 退款异常
+	// 用于兼容回调通知时，通知的数据没有status字段而是refund_status字段
+	RefundStatus *Status `json:"refund_status"`
 	// 退款所使用资金对应的资金账户类型 枚举值： - UNSETTLED : 未结算资金 - AVAILABLE : 可用余额 - UNAVAILABLE : 不可用余额 - OPERATION : 运营户 - BASIC : 基本账户（含可用余额和不可用余额） * `UNSETTLED` - 未结算资金 * `AVAILABLE` - 可用余额 * `UNAVAILABLE` - 不可用余额 * `OPERATION` - 运营户 * `BASIC` - 基本账户（含可用余额和不可用余额）
 	FundsAccount *FundsAccount `json:"funds_account,omitempty"`
 	// 金额详细信息


### PR DESCRIPTION
退款回调通知的plaint text数据中并没有status字段，而是 refund_status 字段，添加`refund_status`用于兼容